### PR TITLE
Update amazon_tag.rb

### DIFF
--- a/amazon_tag.rb
+++ b/amazon_tag.rb
@@ -53,7 +53,7 @@ module Jekyll
 
       recnt = 0
       begin
-        res = Amazon::Ecs.item_lookup(asin)
+        res = Amazon::Ecs.item_search(asin, search_index: 'All')
 
       #Liquid Exception HTTP Response: 503 Service Unavailable
       rescue Amazon::RequestError => e


### PR DESCRIPTION
おそらく issue #2 もなおると思います。 'All'を指定してあげないと、マーケットプレイスが検索対象にならないようです。
(細かいところはおいかけておらず、エイヤと試しただけですが私のoctopressでは動いています)